### PR TITLE
Remove event listeners

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -69,13 +69,33 @@ function startGame(event) {
 function boxSelection() {
   let thisBtn = $(this);
 
-  let valid = verificationCenter(playerTurn, thisBtn);
+  console.log('this button: ' + $(thisBtn).attr('id'));
 
-  if(valid){
+  let winResult = verificationCenter(playerTurn, thisBtn);
+
+  // removes event listener from button once clicked
+  let currentBtn = $(thisBtn).attr('id');
+  currentBtn = document.getElementById(currentBtn);
+  currentBtn.removeEventListener('click' , boxSelection);
+
+  // if(valid){
     render.changeVisible();
     render.changeColor(playerTurn, thisBtn);
     playerTurn = timeGod.turnToggle(playerTurn);
+  // }
+
+  if(winResult){
+    topLeft.removeEventListener("click", boxSelection);
+    topMiddle.removeEventListener("click", boxSelection);
+    topRight.removeEventListener("click", boxSelection);
+    middleLeft.removeEventListener("click", boxSelection);
+    center.removeEventListener("click", boxSelection);
+    middleRight.removeEventListener("click", boxSelection);
+    bottomLeft.removeEventListener("click", boxSelection);
+    bottomMiddle.removeEventListener("click", boxSelection);
+    bottomRight.removeEventListener("click", boxSelection);
   }
+
   let tie = verifyTie(playerOneArray, playerTwoArray);
   if(tie){
     console.log('end')

--- a/utils/verification.mjs
+++ b/utils/verification.mjs
@@ -17,9 +17,9 @@ var playerTwoArray = [];
  */
 function verificationCenter(playerTurn, thisBtn) {
 
-  let validSpace = verifyValidSpace(playerOneArray, playerTwoArray, thisBtn);
+  // let validSpace = verifyValidSpace(playerOneArray, playerTwoArray, thisBtn);
 
-  if(validSpace){
+  // if(validSpace){
     if (playerTurn == 0) {
       let index = $(thisBtn).attr("id").length - 1;
       playerOneArray.push($(thisBtn).attr("id")[index]);
@@ -27,8 +27,8 @@ function verificationCenter(playerTurn, thisBtn) {
       let index = $(thisBtn).attr("id").length - 1;
       playerTwoArray.push($(thisBtn).attr("id")[index]);
     }
-    checkWin(playerOneArray, playerTwoArray, playerTurn);
-    return true;
+    let winResult = checkWin(playerOneArray, playerTwoArray, playerTurn);
+    return winResult;
     // let tie = verifyTie(playerOneArray, playerTwoArray);
 
   //   if(!tie){
@@ -37,7 +37,7 @@ function verificationCenter(playerTurn, thisBtn) {
     
   // } else return false;
   }
-}
+// }
 
 /**
  * Checks to see if/when a player gets 3 in a row.
@@ -66,8 +66,10 @@ function checkWin(playerOneArray, playerTwoArray, playerTurn) {
         playerOneArray.includes(winConditions[i][0]) &&
         playerOneArray.includes(winConditions[i][1]) &&
         playerOneArray.includes(winConditions[i][2])
-      )
-        return console.log("Player 1 Wins!");
+      ){
+        console.log("Player 1 Wins!");
+        return true;
+      }
     }
   } else if (playerTurn == 1) {
     for (let i = 0; i < 8; i++) {
@@ -75,8 +77,10 @@ function checkWin(playerOneArray, playerTwoArray, playerTurn) {
         playerTwoArray.includes(winConditions[i][0]) &&
         playerTwoArray.includes(winConditions[i][1]) &&
         playerTwoArray.includes(winConditions[i][2])
-      )
-        return console.log("Player 2 wins!");
+      ){
+        console.log("Player 2 wins!");
+        return true;
+      }
     }
   }
 }


### PR DESCRIPTION
Removes event listeners from buttons after they are pressed, or when there is a winner.

It's pretty messy, and we have to go through and delete unused commented code, but it works for now.

Will need you to connect your end game menu to the win condition to have it pop up once the game is won.